### PR TITLE
Fix consecutive blank lines in generated files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,10 +144,10 @@ module.exports = {
             "error",
             {
                 "rulesDirectory": [
-                    "/Users/user/dev/web-apidoc2ts/node_modules/tslint-consistent-codestyle/rules",
-                    "/Users/user/dev/web-apidoc2ts/node_modules/tslint-eslint-rules/dist/rules",
-                    "/Users/user/dev/web-apidoc2ts/node_modules/tslint-microsoft-contrib",
-                    "/Users/user/dev/web-apidoc2ts/ts-rules"
+                    "./node_modules/tslint-consistent-codestyle/rules",
+                    "./node_modules/tslint-eslint-rules/dist/rules",
+                    "./node_modules/tslint-microsoft-contrib",
+                    "./ts-rules"
                 ],
                 "rules": {
                     "align": [

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "apidoc2ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Typescript interface generator based on ApiDoc",
   "bin": {
     "apidoc2ts": "./bin/run"
   },
   "main": "src/cli/Index.ts",
   "scripts": {
-    "start": "npm run lint && npm test && npm run build && npm run main",
+    "start": "npm run lint && npm test && npm run build",
     "monitor": "jest --watchAll --verbose",
     "build": "tsc",
     "test": "jest --verbose --passWithNoTests",

--- a/src/core/interfaces-writer/SingleFileInterfacesWriter.test.ts
+++ b/src/core/interfaces-writer/SingleFileInterfacesWriter.test.ts
@@ -1,6 +1,7 @@
 import {ApiDoc2InterfaceGroupingMode} from "../ApiDoc2Interface";
 import {ConverterResult} from "../endpoint-converter/ApiDocToInterfaceConverter";
 import {writeFileToPath} from "../utils/FsUtils";
+import {removeConsecutiveBlankLines} from "../utils/StringUtils";
 import {stringifyAllInterfaces} from "../utils/WriterUtils";
 import {SingleFileInterfacesWriter} from "./SingleFileInterfacesWriter";
 
@@ -62,5 +63,22 @@ describe("Single file interfaces writer", () => {
     it("should call writeFile with given output path and filename", async () => {
         await writer.writeInterfaces(converterResults as Array<ConverterResult>, args);
         expect(writeFileSpy).toBeCalledWith("path/to/the/output/interfaces.ts", expect.anything());
+    });
+});
+
+describe("consecutive blank lines fixer", () => {
+    it("should remove consecutive blank lines", () => {
+        expect(removeConsecutiveBlankLines("interface1\n\n\ninterface2"))
+            .toEqual("interface1\n\ninterface2");
+    });
+
+    it("should remove consecutive blank lines in several places", () => {
+        expect(removeConsecutiveBlankLines("i1\n\n\ni2\n\n\n\ni3"))
+            .toEqual("i1\n\ni2\n\ni3");
+    });
+
+    it("should leave only one newline in end of string", () => {
+        expect(removeConsecutiveBlankLines("i1\n\n"))
+            .toEqual("i1\n");
     });
 });

--- a/src/core/utils/StringUtils.ts
+++ b/src/core/utils/StringUtils.ts
@@ -1,7 +1,13 @@
-export const filterEmptyStrings = (str: string) => str !== "";
+export const filterEmptyStrings = (str: string) => str.trim() !== "";
 
 export function removeFieldsAligningSpaces(interfaceString: string): string {
     return interfaceString.replace(/:\s+/g, ": ");
+}
+
+export function removeConsecutiveBlankLines(string: string): string {
+    return string
+        .replace(/\n([\n])+\n/gm, "\n\n")
+        .replace(/\n\n$/, "\n");
 }
 
 export function getUrlWithoutParameters(url: string) {

--- a/src/core/utils/WriterUtils.ts
+++ b/src/core/utils/WriterUtils.ts
@@ -1,17 +1,21 @@
 import {ConverterResult} from "../endpoint-converter/ApiDocToInterfaceConverter";
-import {filterEmptyStrings} from "./StringUtils";
+import {filterEmptyStrings, removeConsecutiveBlankLines} from "./StringUtils";
 
 export function stringifyInterfaces(converterResult: ConverterResult): string {
-    return [
+    const stringifiedInterfaces = [
         converterResult.requestInterface,
         converterResult.responseInterface,
         converterResult.errorInterface,
     ].filter(filterEmptyStrings).join("\n");
+
+    return removeConsecutiveBlankLines(stringifiedInterfaces);
 }
 
 export function stringifyAllInterfaces(converterResults: Array<ConverterResult>): string {
-    return converterResults
+    const stringifiedInterfaces = converterResults
         .map((endpointData) => stringifyInterfaces(endpointData))
         .filter(filterEmptyStrings)
         .join("\n");
+
+    return removeConsecutiveBlankLines(stringifiedInterfaces);
 }


### PR DESCRIPTION
- [x]  I wrote/rewrote tests for the changes
- [x]  I have tested the changes

#### Short description
In generated files you could find interfaces, separated by 3 blank lines
Also there are situations with 2 blank lines in EOF
Implemented blankline eraser
Also fixed linter path and "start" script
